### PR TITLE
Avoid mandatory pkg_resources import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
-sudo: false
 cache: pip
 python:
-- 2.7
-- 3.4
-- 3.5
-- 3.6
-- pypy
+- 3.10
+- 3.11
+- 3.12
+- 3.13
 install:
 - pip install tox-travis
 script:
@@ -17,7 +15,7 @@ stages:
 jobs:
   include:
   - stage: deploy
-    python: 3.6
+    python: 3.10
     install: skip  # no tests, no depedencies needed
     script: skip  # we're not running tests
     deploy:

--- a/rst2txt/__init__.py
+++ b/rst2txt/__init__.py
@@ -13,14 +13,15 @@ locale.setlocale(locale.LC_ALL, '')  # noqa
 
 from docutils.core import default_description
 from docutils.core import publish_cmdline
-from pkg_resources import DistributionNotFound
-from pkg_resources import get_distribution
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
 
 from rst2txt.writer import Writer
 
+
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,15 +21,13 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
-    Programming Language :: Python :: Implementation :: PyPy
     Topic :: Documentation
     Topic :: Internet :: WWW/HTTP :: Site Management
     Topic :: Printing
@@ -44,14 +42,13 @@ classifiers =
 zip_safe = False
 packages = find:
 include_package_data = True
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+python_requires = >=3.10
 setup_requires =
     setuptools>=30.3.0
     setuptools_scm
 install_requires =
     docutils>=0.11
     pygments  # necessary for code-block directive, code role
-    setuptools  # necessary for pkg_resources
 
 [options.extras_require]
 test =
@@ -62,16 +59,13 @@ test =
 exclude =
     tests
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 95
 ignore = E116,E241,E251,E741,I101,W504
 exclude = .git,.tox,.venv,.eggs,build/*,doc
 
 [mypy]
-python_version = 2.7
+python_version = 3.10
 show_column_numbers = True
 show_error_context = True
 ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 minversion = 2.4
-envlist = py{27,34,35,36,py},style,coverage,mypy
+envlist = py{310,311,312,313},style,coverage,mypy
 
 [testenv]
 usedevelop = True
 passenv =
     https_proxy http_proxy no_proxy PYTEST_ADDOPTS
 description =
-    py{27,34,35,36,37}: Run unit tests against {envname}.
+    py{310,311,312,313}: Run unit tests against {envname}.
 extras =
     test
 commands=


### PR DESCRIPTION
Fixes #2.

`rst2txt` imported `pkg_resources` at module import time just to read the installed package version. With recent setuptools releases, `pkg_resources` may be absent, which makes `import rst2txt` fail before callers can use the package.

This now drops support for Python < 3.10 and uses stdlib `importlib.metadata` directly for version discovery. It also removes the runtime `setuptools` dependency, drops the universal wheel marker, and updates the packaging/test metadata away from EOL Python versions.

Not run locally.